### PR TITLE
Honour user-supplied encodings

### DIFF
--- a/index.js
+++ b/index.js
@@ -71,7 +71,7 @@ function getOptions(uri, o, method) {
     if (o.encoding === undefined) {
         o.encoding = null;
     } else {
-        o.encodingProvided = true;
+        o._encodingProvided = true;
     }
 
     return o;
@@ -140,7 +140,7 @@ Request.prototype.run = function () {
             var response = responses[0];
             var body = responses[1]; // decompressed
 
-            if (body && response.headers && !self.options.encodingProvided) {
+            if (body && response.headers && !self.options._encodingProvided) {
                 var contentType = response.headers['content-type'];
                 if (/^text\/|application\/json\b/.test(contentType)) {
                     // Convert buffer to string

--- a/index.js
+++ b/index.js
@@ -68,8 +68,10 @@ function getOptions(uri, o, method) {
     }
 
     // Default to binary requests (return buffer)
-    if (!o.encoding) {
+    if (o.encoding === undefined) {
         o.encoding = null;
+    } else {
+        o.encodingProvided = true;
     }
 
     return o;
@@ -138,7 +140,7 @@ Request.prototype.run = function () {
             var response = responses[0];
             var body = responses[1]; // decompressed
 
-            if (body && response.headers) {
+            if (body && response.headers && !self.options.encodingProvided) {
                 var contentType = response.headers['content-type'];
                 if (/^text\/|application\/json\b/.test(contentType)) {
                     // Convert buffer to string

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -23,7 +23,6 @@ describe('preq', function() {
     });
     it('get google.com', function() {
         return preq.get({
-            // Some unreachable port
             uri: 'http://google.com/',
             retries: 2
         })
@@ -62,6 +61,20 @@ describe('preq', function() {
         .then(function(res) {
             assert.equal(res.status, 200);
             assert.equal(!!res.body, true);
+        });
+    });
+    it('return buffer on user-supplied encoding', function() {
+        return preq('http://google.com/', {encoding: null})
+        .then(function(res) {
+            assert.equal(res.status, 200);
+            assert.equal(res.body.constructor.name, 'Buffer');
+        });
+    });
+    it('return string with no encoding', function() {
+        return preq('http://google.com/')
+        .then(function(res) {
+            assert.equal(res.status, 200);
+            assert.equal(typeof res.body, 'string');
         });
     });
 });


### PR DESCRIPTION
When a user supplies `encoding: null`, they expect to be given a
Buffer object in return regardless of the content's type, so honour
that. Also, add some tests for this case and bump the version to 0.4.1
