### PR TITLE
Identify Buffers when parsing responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -149,7 +149,10 @@ Request.prototype.run = function () {
                 }
 
                 if (/^application\/(?:problem\+)?json\b/.test(contentType)) {
-                    body = JSON.parse(body);
+                    body = JSON.parse(body, function(key, value) {
+                        return ((value instanceof Object) && (value.type == 'Buffer'))
+                            ? new Buffer(value.data) : value;
+                    });
                 }
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Problem: `JSON.stringify()` of a `Buffer` serialises it as 

```
{
   type: "Buffer",
   data: [ < data array > ]
}
```

So, when we parse the response from a backend service, like graphoid `/all` response for png content, we were parsing binary content as it is in the JSON - just an ordinary object with `type` and `data` properties, so after RESTBase sends the response to the client, for binary content wrapped in JSON it becomes incorrect.

This is a known problem in node, and a fix is described [here](https://github.com/nodejs/node-v0.x-archive/issues/5110). 
