### PR TITLE
Content encoding: Ensure gzip is set correctly and remove the header

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {

--- a/test/index.js
+++ b/test/index.js
@@ -90,5 +90,14 @@ describe('preq', function() {
             assert.equal(typeof res.body, 'string');
         });
     });
+    it('no content-encoding header for gzipped responses', function() {
+        return preq({
+            uri: 'https://en.wikipedia.org/api/rest_v1/page/html/Foobar',
+            gzip: true
+        }).then(function(res) {
+            assert.equal(res.status, 200);
+            assert.equal(res.headers['content-encoding'], undefined);
+        });
+    });
 });
 


### PR DESCRIPTION
We have been forcing gzip whenever it hasn't been defined for GET
requests. However, we need to set it to true also for cases where
clients provide the content-encoding header.

This is also a bug fix that removes the content-encoding header from
the response whenever gzip is set because the request library implicitly
decompresses the body, but it fails to remove the content-encoding
header, causing inconsistencies in the returned response.

In the same vein, the content-length header is removed whenever the
response is decompressed or decoded.
