### PR TITLE
Updated to bluebird 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/**

--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ var url = require('url');
 
 var util = require('util');
 
-var request = P.promisify(require('request'));
+var request = P.promisify(require('request'), { multiArgs: true });
 
 function getOptions(uri, o, method) {
     if (!o || o.constructor !== Object) {
@@ -91,7 +91,6 @@ function HTTPError(response) {
     if (response.body && response.body.type) {
         this.message += ': ' + response.body.type;
     }
-
     for (var key in response) {
         this[key] = response[key];
     }
@@ -127,7 +126,7 @@ Request.prototype.retry = function (err) {
 
 Request.prototype.run = function () {
     var self = this;
-    return P.try(request, this.options)
+    return P.try(function() { return request(self.options) })
     .bind(this)
     .then(function(responses) {
         if (!responses || responses.length < 2) {

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
   "author": "Gabriel Wicke <gwicke@wikimedia.org>",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "^3.0.6",
+    "bluebird": "^3.1.1",
     "request": "^2.67.0"
   },
   "devDependencies": {
-    "mocha": "x.x.x"
+    "mocha": "^2.3.4"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {
@@ -9,8 +9,8 @@
   "author": "Gabriel Wicke <gwicke@wikimedia.org>",
   "license": "MIT",
   "dependencies": {
-    "bluebird": "~2.8.2",
-    "request": "^2.55.0"
+    "bluebird": "^3.0.6",
+    "request": "^2.67.0"
   },
   "devDependencies": {
     "mocha": "x.x.x"


### PR DESCRIPTION
Updated to use bluebird 3. This was tested in staging for some time and the results seem good.

Also, bluebird 3 has deprecated `P.try(function, arguments)` style of call, so avoid using that.
Another thing is that `promisify` behaviour changed in an incompatible manner - now if the callback we're promisifying has more that 2 arguments, only the first one is returned to the promise. Old behaviour is switched on with `multiArgs` flag. 
