### PR TITLE
Pool or no pool

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
     - "0.10"
-    - "0.11"
     - "0.12"
-    - "iojs"
-
+    - "4"
+    - "node"

--- a/index.js
+++ b/index.js
@@ -117,11 +117,6 @@ function getOptions(uri, o, method) {
         o.timeout = 2 * 60 * 1000; // 2 minutes
     }
 
-    // Default pool options: Don't limit the number of sockets
-    if (!o.pool) {
-        o.pool = {maxSockets: Infinity};
-    }
-
     if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding'])) || (o.gzip === undefined && o.method === 'get')) {
         o.gzip = true;
     }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.1.1",
-    "request": "^2.67.0"
+    "request": "^2.67.0",
+    "semver": "^5.1.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
8dccd56 should have failed but the global agent was never being used because of the default pool settings. There's an incompatibility with v5.7 of node that's fixed in b2c7bb8.

If you want to set that pool then we should set the `agentClass` to this `ConnectTimeoutAgent` presumably.

/cc @wikimedia/services 
