### PR TITLE
Take querystring into account when detecting a redirect

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 var P = require('bluebird');
 var url = require('url');
 var util = require('util');
+var querystring = require('querystring');
 
 function setupConnectionTimeout(protocol) {
     var http = require(protocol);
@@ -195,7 +196,12 @@ Request.prototype.run = function () {
             };
 
             // Check if we were redirected
-            if (self.options.uri !== response.request.uri.href) {
+            var origURI = self.options.uri;
+            if (self.options.qs && Object.keys(self.options.qs).length) {
+                origURI += '?' + querystring.stringify(self.options.qs);
+            }
+            
+            if (origURI !== response.request.uri.href) {
                 if (!res.headers['content-location']) {
                     // Indicate the redirect via an injected Content-Location
                     // header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
We wrongly detect a redirect if there was a query string on the request.

cc @wikimedia/services 
