### PR TITLE
No body for 204, 205 and 304; release v0.4.12

### DIFF
--- a/index.js
+++ b/index.js
@@ -190,6 +190,12 @@ Request.prototype.run = function () {
                 }
             }
 
+            // 204, 205 and 304 responses must not contain any body
+            if (response.statusCode === 204 || response.statusCode === 205
+                    || response.statusCode === 304) {
+                body = undefined;
+            }
+
             var res = {
                 status: response.statusCode,
                 headers: response.headers,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.11",
+  "version": "0.4.12",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Status codes 204, 205 and 304 indicate responses without bodies, so enforce
this by stripping it away, as sometimes we may receive emptry strings or
buffers for it.
