### PR TITLE
Fix the connection timeout agent

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
     - "0.10"
-    - "0.11"
-    - "0.12"
-    - "iojs"
+    - "4"
+    - "6"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.4.12",
+  "version": "0.5.0",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {
@@ -10,7 +10,8 @@
   "license": "MIT",
   "dependencies": {
     "bluebird": "^3.1.1",
-    "request": "^2.67.0"
+    "request": "^2.67.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "mocha": "^2.3.4"


### PR DESCRIPTION
Two things have changed:
 - The `request` library started to mangle the agent itself, so we need to provide `agentClass` and `agentOptions` now instead of setting the `globalAgent` in the http/https modules.
 - In the newer node versions the `createSocket` method is async, so accommodate for that.

cc @wikimedia/services 