### PR TITLE
Test node 5.6 / 5.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ language: node_js
 node_js:
     - "0.10"
     - "4"
+    # Test 5.6 / 5.7 as well, as the agent behavior changed between those
+    # versions.
+    - "5.6"
+    - "5.7"
     - "6"
 


### PR DESCRIPTION
The agent interfaces changed between 5.6 & 5.7, and our code now has two
code paths depending on a version check. By testing both versions
explicitly in travis, we make sure that this version check is accurate.