### PR TITLE
Add support for increasing connect timeout with an env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Additionally, it defines or modifies these request options:
     - `application/x-www-form-urlencoded`
 - `retries`: Maximum number of retries. Exponential back-off is used between retries.
 - `timeout`: Total request timeout. 
-- `connectTimeout`: Maximum time to establish a TCP connection to the host, in
-    ms. Useful to quickly fail if a node is unreachable at the network level,
-    without waiting for the full `timeout` duration.
+
+The connection timeout, maximum time to establish a TCP connection to the host is 5 seconds by default
+and can be altered with `PREQ_CONNECT_TIMEOUT` environment variable.
 
 
 Also see [the tests](/test/index.js) for usage examples.

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function createConnectTimeoutAgent(protocol) {
 }
 
 var agentOptions = {
-    connectTimeout: (process.env.CONNECT_TIMEOUT || 5) * 1000,
+    connectTimeout: (process.env.PREQ_CONNECT_TIMEOUT || 5) * 1000,
     // Setting this too high (especially 'Infinity') leads to high
     // (hundreds of mb) memory usage in the agent under sustained request
     // workloads. 250 should be a reasonable upper bound for practical

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function createConnectTimeoutAgent(protocol) {
 }
 
 var agentOptions = {
-    connectTimeout: 5 * 1000,
+    connectTimeout: (process.env.CONNECT_TIMEOUT || 5) * 1000,
     // Setting this too high (especially 'Infinity') leads to high
     // (hundreds of mb) memory usage in the agent under sustained request
     // workloads. 250 should be a reasonable upper bound for practical

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
For #23 

The tests started to fail after the connect timeous finally started to work. Apparently connect from within docker for mac could be terribly slow, so increasing the timeout with an env variable should be possible.

cc @wikimedia/services @mdholloway 