### PR TITLE
Fix: Use `o.uri || o.url` to check for the protocol to use; rel v0.5.1

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,7 @@ function getOptions(uri, o, method) {
     } else {
         o.uri = uri;
     }
+    o.uri = o.uri || o.url;
     o.method = method;
     if (o.body && o.body instanceof Object) {
         if (o.headers && /^application\/json/.test(o.headers['content-type'])) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Until preq 0.5.0 clients could you use either the `uri` or the `url`
property to specify the URL to send the request to. However, as of
v0.5.0, preq checks for the protocol the use only for `uri` which breaks
clients, so resurrect the compatibility with `url`.