### PR TITLE
Ensure all header names are lower-cased; release v0.5.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 language: node_js
 node_js:
-    - "0.10"
-    - "4"
-    # Test 5.6 / 5.7 as well, as the agent behavior changed between those
-    # versions.
-    - "5.6"
-    - "5.7"
-    - "6"
-
+  - "4"
+  # Test 5.6 / 5.7 as well, as the agent behavior changed between those
+  # versions.
+  - "5.6"
+  - "5.7"
+  - "6"
+  - "8"
+  - "node"

--- a/index.js
+++ b/index.js
@@ -84,6 +84,13 @@ function getOptions(uri, o, method) {
     }
     o.uri = o.uri || o.url;
     o.method = method;
+    o.headers = o.headers || {};
+    Object.keys(o.headers).forEach(function(header) {
+        if (header.toLowerCase() !== header) {
+            o.headers[header.toLowerCase()] = o.headers[header];
+            delete o.headers[header];
+        }
+    });
     if (o.body && o.body instanceof Object) {
         if (o.headers && /^application\/json/.test(o.headers['content-type'])) {
             o.body = JSON.stringify(o.body);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Header names are case-insensitive, so make sure all their names are lower-cased before performing any request manipulations.

Fixes #29 