### PR TITLE
Don't set the default `pool` option; release v0.5.4

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,7 +114,7 @@ function getOptions(uri, o, method) {
     // Set a timeout by default
     if (o.timeout === undefined) {
         o.timeout = 2 * 60 * 1000; // 2 minutes
-    }   
+    }
 
     if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding'])) || (o.gzip === undefined && o.method === 'get')) {
         o.gzip = true;

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function createConnectTimeoutAgent(protocol) {
     return ConnectTimeoutAgent;
 }
 
-var agentOptions = {
+var defaultAgentOptions = {
     connectTimeout: (process.env.PREQ_CONNECT_TIMEOUT || 5) * 1000,
     // Setting this too high (especially 'Infinity') leads to high
     // (hundreds of mb) memory usage in the agent under sustained request
@@ -114,12 +114,7 @@ function getOptions(uri, o, method) {
     // Set a timeout by default
     if (o.timeout === undefined) {
         o.timeout = 2 * 60 * 1000; // 2 minutes
-    }
-
-    // Default pool options: Don't limit the number of sockets
-    if (!o.pool) {
-        o.pool = {maxSockets: Infinity};
-    }
+    }   
 
     if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding'])) || (o.gzip === undefined && o.method === 'get')) {
         o.gzip = true;
@@ -133,7 +128,7 @@ function getOptions(uri, o, method) {
     }
 
     o.agentClass = /^https/.test(o.uri) ? httpsAgentClass : httpAgentClass;
-    o.agentOptions = agentOptions;
+    o.agentOptions = Object.assign(defaultAgentOptions, o.agentOptions || {});
 
     return o;
 }

--- a/index.js
+++ b/index.js
@@ -128,7 +128,7 @@ function getOptions(uri, o, method) {
     }
 
     o.agentClass = /^https/.test(o.uri) ? httpsAgentClass : httpAgentClass;
-    o.agentOptions = Object.assign(defaultAgentOptions, o.agentOptions || {});
+    o.agentOptions = Object.assign({}, defaultAgentOptions, o.agentOptions);
 
     return o;
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.6.0",
+  "version": "0.5.4",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.3",
+  "version": "0.6.0",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
In case the `pool` option is used, it overrides the agentOptions provided and also it prevents the `request` lib from using a global agent pool. That means that on every request a new agent is created which is not only wasteful, but also drives maxSockets option useless as the Agent is destroyed after each request and prevents using keepAlive.

Additionally provide an option to specify agentOptions from the outside. This is a pretty dangerous option as in case the options differ a new agent will be created. With stuff like maxSockets or keepAlive having several agent instances might lead to unexpected consequences, but we want to set keepAlive from the outside of preq (not use it by default for all the services), so this is the only option)

cc @wikimedia/services @arlolra 