### PR TITLE
Better compare the URIs for redirects.

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,8 @@ Request.prototype.run = function () {
                 origURI += '?' + querystring.stringify(self.options.qs);
             }
             
-            if (url.format(origURI) !== response.request.uri.href) {
+            if (origURI !== response.request.uri.href
+                    && url.format(origURI) !== response.request.uri.href) {
                 if (!res.headers['content-location']) {
                     // Indicate the redirect via an injected Content-Location
                     // header

--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ Request.prototype.run = function () {
                 origURI += '?' + querystring.stringify(self.options.qs);
             }
             
-            if (origURI !== response.request.uri.href) {
+            if (url.format(origURI) !== response.request.uri.href) {
                 if (!res.headers['content-location']) {
                     // Indicate the redirect via an injected Content-Location
                     // header

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
According to node docs the encoding used by url.format and
pure JS encodeURIComponent might be different. The request
module uses url.format under the hood so to better compare
the original and final url we need to format the original as well.

cc @wikimedia/services @elukey