### PR TITLE
Removed eslint-config-node-services and mocha-eslint. 

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
-coverage
+test/
+coverage/
 node_modules
 .idea

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,34 @@
-extends: 'eslint-config-node-services'
+extends: 
+  - 'wikimedia/server'
+
+plugins:
+  - json
+  - jsdoc
+
+rules:
+  array-bracket-spacing:
+    - off
+  camelcase:
+    - error
+    - properties: never
+  computed-property-spacing:
+    - error
+    - never
+  indent: 
+    - error
+    - 4
+    - SwitchCase: 1
+      MemberExpression: 'off'
+  no-multi-spaces:
+    - off
+  # defined in eslint-config-wikimedia to avoid breaking IE. Not needed here
+  no-restricted-syntax:
+    - off    
+  no-underscore-dangle:
+    - off
+  no-unused-vars:
+    - error
+    - args: none
+  space-in-parens:
+    - error
+    - never

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 coverage
 node_modules
 .idea
+.vscode/
+npm-debug.log

--- a/index.js
+++ b/index.js
@@ -71,8 +71,7 @@ function getOptions(uri, o, method) {
         }
     }
 
-    if ((o.method === 'get' || o.method === 'put') &&
-        o.retries === undefined) {
+    if ((o.method === 'get' || o.method === 'put') && o.retries === undefined) {
         // Idempotent methods: Retry once by default
         o.maxAttempts = 2;
     } else {
@@ -90,7 +89,7 @@ function getOptions(uri, o, method) {
     }
 
     if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding'])) ||
-        (o.gzip === undefined && o.method === 'get')) {
+            (o.gzip === undefined && o.method === 'get')) {
         o.gzip = true;
     }
 
@@ -174,7 +173,7 @@ class Request {
 
             // 204, 205 and 304 responses must not contain any body
             if (response.statusCode === 204 || response.statusCode === 205 ||
-                response.statusCode === 304) {
+                    response.statusCode === 304) {
                 body = undefined;
             }
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 const P = require('bluebird');
 const url = require('url');
@@ -71,8 +71,8 @@ function getOptions(uri, o, method) {
         }
     }
 
-    if ((o.method === 'get' || o.method === 'put')
-        && o.retries === undefined) {
+    if ((o.method === 'get' || o.method === 'put') &&
+        o.retries === undefined) {
         // Idempotent methods: Retry once by default
         o.maxAttempts = 2;
     } else {
@@ -89,8 +89,8 @@ function getOptions(uri, o, method) {
         o.timeout = 2 * 60 * 1000; // 2 minutes
     }
 
-    if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding']))
-        || (o.gzip === undefined && o.method === 'get')) {
+    if ((o.headers && /\bgzip\b/.test(o.headers['accept-encoding'])) ||
+        (o.gzip === undefined && o.method === 'get')) {
         o.gzip = true;
     }
 
@@ -125,7 +125,6 @@ class HTTPError extends Error {
     }
 }
 
-
 /*
  * Encapsulate the state associated with a single HTTP request
  */
@@ -139,10 +138,10 @@ class Request {
             this.delay = this.delay * 2 + this.delay * Math.random();
             return delay;
         };
-        this.options.promiseFactory = resolver => new P(resolver);
+        this.options.promiseFactory = (resolver) => new P(resolver);
         this.options.retryStrategy = (err, response) => {
-            if (response && response.statusCode === 503
-                    && /^[0-9]+$/.test(response.headers['retry-after'])) {
+            if (response && response.statusCode === 503 &&
+                    /^[0-9]+$/.test(response.headers['retry-after'])) {
                 this.delay = parseInt(response.headers['retry-after'], 10) * 1000;
                 return true;
             }
@@ -174,8 +173,8 @@ class Request {
             }
 
             // 204, 205 and 304 responses must not contain any body
-            if (response.statusCode === 204 || response.statusCode === 205
-                || response.statusCode === 304) {
+            if (response.statusCode === 204 || response.statusCode === 205 ||
+                response.statusCode === 304) {
                 body = undefined;
             }
 
@@ -191,8 +190,8 @@ class Request {
                 origURI += `?${querystring.stringify(this.options.qs)}`;
             }
 
-            if (origURI !== response.request.uri.href
-                && url.format(origURI) !== response.request.uri.href) {
+            if (origURI !== response.request.uri.href &&
+                url.format(origURI) !== response.request.uri.href) {
                 if (!res.headers['content-location']) {
                     // Indicate the redirect via an injected Content-Location
                     // header
@@ -219,7 +218,7 @@ class Request {
                     error: err,
                     stack: err.stack,
                     uri: this.options.uri,
-                    method: this.options.method,
+                    method: this.options.method
                 },
                 stack: err.stack
             });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {
-    "test": "mocha && nsp check",
+    "test": "npm run lint && mocha",
+    "lint": "eslint --max-warnings 0 --ext .js --ext .json .",
     "coverage": "istanbul cover _mocha -- -R spec",
     "coveralls": "cat ./coverage/lcov.info | coveralls"
   },
@@ -20,17 +21,13 @@
   },
   "devDependencies": {
     "coveralls": "^3.0.2",
-    "eslint-config-node-services": "^2.2.5",
-    "eslint-config-wikimedia": "^0.8.1",
+    "eslint-config-wikimedia": "^0.10.0",
     "eslint-plugin-jsdoc": "^3.9.1",
     "eslint-plugin-json": "^1.2.1",
-    "eslint": "^5.8.0",
     "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
-    "mocha-eslint": "^4.1.0",
     "mocha-lcov-reporter": "^1.3.0",
-    "nock": "^10.0.1",
-    "nsp": "^3.2.1"
+    "nock": "^10.0.1"
   },
   "repository": {
     "type": "git",

--- a/test/index.js
+++ b/test/index.js
@@ -5,8 +5,6 @@ const zlib = require('zlib');
 const preq = require('../index');
 const assert = require('assert');
 
-require('mocha-eslint')([ '.' ]);
-
 describe('preq', function() {
     this.timeout(30000); // eslint-disable no-invalid-this
 


### PR DESCRIPTION
Also removed nsp since apparently it [has been shutdown (StackOverflow)](https://stackoverflow.com/questions/53716991/node-security-service-shutdown-getaddrinfo-enotfound-api-nodesecurity-io) and now throws an exception. 
+) Client request error: getaddrinfo ENOTFOUND api.nodesecurity.io api.nodesecurity.io:443
