### PR TITLE
HTTPError: Improve error message; release v0.5.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 coverage
 .nyc_output
 node_modules
+package-lock.json
 .idea
 .vscode
 npm-debug.log

--- a/index.js
+++ b/index.js
@@ -121,9 +121,12 @@ class HTTPError extends Error {
         super();
         Error.captureStackTrace(this, HTTPError);
         this.name = this.constructor.name;
-        this.message = response.status.toString();
-        if (response.body && response.body.type) {
-            this.message += `: ${response.body.type}`;
+        const status = response && response.status.toString() || '504';
+        if (!response || !response.body) {
+            this.message = `${status}: http_error`;
+        } else {
+            this.message = response.body.detail || response.body.message ||
+                response.body.description || `${status}: ${response.body.type || 'http_error'}`;
         }
         Object.assign(this, response);
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.8",
+  "version": "0.5.9",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {
@@ -15,16 +15,15 @@
     "node": ">=6.0.0"
   },
   "dependencies": {
-    "bluebird": "^3.5.2",
+    "bluebird": "^3.5.5",
     "request": "^2.88.0",
-    "requestretry": "^3.0.2"
+    "requestretry": "^4.0.0"
   },
   "devDependencies": {
     "coveralls": "^3.0.2",
     "eslint-config-wikimedia": "^0.10.0",
     "eslint-plugin-jsdoc": "^3.9.1",
     "eslint-plugin-json": "^1.2.1",
-    "istanbul": "^0.4.5",
     "mocha": "^5.2.0",
     "mocha-lcov-reporter": "^1.3.0",
     "nock": "^10.0.1",


### PR DESCRIPTION
Previously, preq was imposing the error message based on the status and type. Now, it checks for an existing message or detail before doing so.

Bug: [T225329](https://phabricator.wikimedia.org/T225329)