### PR TITLE
Include query string in HTTPError body

### DIFF
--- a/index.js
+++ b/index.js
@@ -239,6 +239,10 @@ class Request {
                 return res;
             }
         }, (err) => {
+            let query = this.options.qs;
+            if (typeof query === 'object') {
+                query = JSON.stringify(query);
+            }
             throw new HTTPError({
                 status: err.status || 504,
                 headers: {
@@ -249,6 +253,7 @@ class Request {
                     detail: err.message,
                     internalStack: err.stack,
                     internalURI: this.options.uri.toString(),
+                    internalQuery: query,
                     internalErr: err.message,
                     internalMethod: this.options.method
                 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "preq",
-  "version": "0.5.12",
+  "version": "0.5.13",
   "description": "Yet another promising request wrapper",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently the only facts about the original request that are included in
the logged HTTPError on request failure are the URI and method. More is
required in the case of requests POSTed to the MediaWiki API in order to
identify problematic requests. This updates the HTTPError generated on
request failure to include any query string present in the original
request. This is needed to debug persistent MW API timeouts observed in
mobileapps.