### PR TITLE
Pinned requestretry to version 4.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "bluebird": "^3.5.5",
     "request": "^2.88.0",
-    "requestretry": "^4.0.0"
+    "requestretry": "4.0.2"
   },
   "devDependencies": {
     "coveralls": "^3.0.5",


### PR DESCRIPTION
Version 4.1 breaks compatibility with Node 6